### PR TITLE
parseCanonicalUri() needs to be static as it's only referenced staticall...

### DIFF
--- a/ElasticTranscoder.php
+++ b/ElasticTranscoder.php
@@ -600,7 +600,7 @@ class AWS_ET {
     return reset($unpack);
   }
 
-  private function parseCanonicalUri($url) {
+  private static function parseCanonicalUri($url) {
     $parts = parse_url($url);
     $str = '';
     if (isset($parts['scheme'])) {


### PR DESCRIPTION
`parseCanonicalUri()` is only referenced in one place: `self::parseCanonicalUri(...)`, this fails.
